### PR TITLE
Platform agnostic keybinding

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Declarative, lightweight, and robust keybindings mixin for React.
   to the `keybinding` method of that component
 * Doesn't fire keybindings accidentally triggered in inputs,
   select boxes, or textareas.
+* Optionally coerce platform specific keybindings (i.e. `'⌘S'` on Mac to `'^S'` on Windows)
 
 ## Installation
 
@@ -29,6 +30,7 @@ var React = require('react'),
     Keybinding = require('../');
 var HelloMessage = React.createClass({
   mixins: [Keybinding],
+  keybindingsPlatformAgnostic: true,
   keybindings: {
     '⌘S': function(e) {
       console.log('save!');
@@ -79,6 +81,16 @@ keybindings: {
 }
 ```
 
+Platform agnostic keybindings will automatically listen for the `'Ctrl'`
+equivalent of `'Cmd'` keybindings, and vice-versa. To automatically coerce
+platform specific keybindings, provide a property called
+`keybindingsPlatformAgnostic` of the format:
+
+```js
+keybindingsPlatformAgnostic: true,
+keybindings: { ... }
+```
+
 The mixin provides a method for components called `.getAllKeybindings()`:
 this yields an array of all `keybindings` properties on all active components.
 
@@ -91,5 +103,3 @@ The full [range of codes and modifiers supported is listed in SYNTAX.md](SYNTAX.
 ```sh
 $ npm test
 ```
-
-

--- a/index.js
+++ b/index.js
@@ -63,7 +63,7 @@ var Keybinding = {
    */
   componentDidMount: function() {
     if (this.keybindings !== undefined) {
-      this.matchers = parseEvents(this.keybindings);
+      this.matchers = parseEvents(this.keybindings, !!this.keybindingsPlatformAgnostic);
       document.addEventListener('keydown', this.__keybinding);
       this.__getKeybindings().push(this.keybindings);
     }

--- a/src/parse_events.js
+++ b/src/parse_events.js
@@ -6,15 +6,30 @@ var parseCode = require('./parse_code.js');
  * return an array of parsed keystroke
  * expectations and actions.
  * @param {Object} keybindings
+ * @param {Boolean} platformAgnostic convert platform specific keybindgs
  * @returns {Array<Object>} matchers
  */
-module.exports = function(keybindings) {
+module.exports = function(keybindings, platformAgnostic) {
   var matchers = [];
   for (var code in keybindings) {
+    var event = parseCode(code);
     matchers.push({
-      expectation: parseCode(code),
+      expectation: event,
       action: keybindings[code]
     });
+    if (platformAgnostic && (event.metaKey ? !event.ctrlKey : event.ctrlKey)) {
+      // meta xor ctrl
+      matchers.push({
+        expectation: {
+          keyCode: event.keyCode,
+          shiftKey: event.shiftKey,
+          ctrlKey: !event.ctrlKey,
+          altKey: event.altKey,
+          metaKey: !event.metaKey
+        },
+        action: keybindings[code]
+      });
+    }
   }
   return matchers;
 };

--- a/test.js
+++ b/test.js
@@ -57,6 +57,50 @@ test('parseEvents', function(t) {
     t.end();
 });
 
+test('parseEvents platformAgnostic', function(t) {
+    t.deepEqual(parseEvents({'a':'b'}, true), [{
+      expectation: {
+        altKey: false, ctrlKey: false, keyCode: 65, metaKey: false, shiftKey: false
+      },
+      action: 'b'
+    }], 'ignore neither cmd nor ctrl');
+    t.deepEqual(parseEvents({'cmd+a':'b'}, true), [
+      {
+        expectation: {
+          altKey: false, ctrlKey: false, keyCode: 65, metaKey: true, shiftKey: false
+        },
+        action: 'b'
+      },
+      {
+        expectation: {
+          altKey: false, ctrlKey: true, keyCode: 65, metaKey: false, shiftKey: false
+        },
+        action: 'b'
+      }
+    ], 'convert cmd to ctrl');
+    t.deepEqual(parseEvents({'ctrl+a':'b'}, true), [
+      {
+        expectation: {
+          altKey: false, ctrlKey: true, keyCode: 65, metaKey: false, shiftKey: false
+        },
+        action: 'b'
+      },
+      {
+        expectation: {
+          altKey: false, ctrlKey: false, keyCode: 65, metaKey: true, shiftKey: false
+        },
+        action: 'b'
+      }
+    ], 'convert ctrl to cmd');
+    t.deepEqual(parseEvents({'cmd+ctrl+a':'b'}, true), [{
+      expectation: {
+        altKey: false, ctrlKey: true, keyCode: 65, metaKey: true, shiftKey: false
+      },
+      action: 'b'
+    }], 'ignore both cmd and ctrl');
+    t.end();
+});
+
 var React = require('react/addons'),
     happen = require('happen'),
     TestUtils = React.addons.TestUtils;


### PR DESCRIPTION
Currently, if a keybinding is defined for Cmd-S and the user types
Ctrl-S, the event is not dispatched to the handler. Likewise, keybindings
defined with Ctrl are not handled if the user types Cmd. Platform
agnostic keybinding automatically listens for both the Cmd and Ctrl
variants of a keybinding.

Platform agnostic keybinding is opt-in, requiring the component to
declare it's intention with a property in the form:

```
keybindingsPlatformAgnostic: true,
keybindings: { ... }
```

Issue: #7
