### PR TITLE
bind internal __keybinding to component

### DIFF
--- a/index.js
+++ b/index.js
@@ -64,7 +64,8 @@ var Keybinding = {
   componentDidMount: function() {
     if (this.keybindings !== undefined) {
       this.matchers = parseEvents(this.keybindings, !!this.keybindingsPlatformAgnostic);
-      document.addEventListener('keydown', this.__keybinding);
+      this.__boundKeybinding = this.__keybinding.bind(this);
+      document.addEventListener('keydown', this.__boundKeybinding);
       this.__getKeybindings().push(this.keybindings);
     }
   },
@@ -74,8 +75,8 @@ var Keybinding = {
    * remove our keybindings from the global index.
    */
   componentWillUnmount: function() {
-    if (this.keybindings !== undefined) {
-      document.removeEventListener('keydown', this.__keybinding);
+    if (this.keybindings !== undefined && this.__boundKeybinding !== undefined) {
+      document.removeEventListener('keydown', this.__boundKeybinding);
       this.__getKeybindings()
         .splice(this.__getKeybindings().indexOf(this.keybindings), 1);
     }


### PR DESCRIPTION
When in use with the quite popular [brigand/react-mixin](https://github.com/brigand/react-mixin) ES7 decorator, the internal `__keybinding` method cannot access the mixin under `this` and the mixin does not work. Instead, `this` refers to `document`.

By binding `__keybinding` to `this` before adding it as `keydown` EventListener, everything works as it's supposed to.
