### PR TITLE
Flag for binding keys when focused on an input

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,7 +42,7 @@ var Keybinding = {
    * and then either fires an inline method or the .keybinding() method.
    */
   __keybinding: function(event) {
-    if (isInput(event)) return;
+    if (isInput(event) && !!this.keybindingsOnInputs) return;
     for (var i = 0; i < this.matchers.length; i++) {
       if (match(this.matchers[i].expectation, event)) {
         if (typeof this.matchers[i].action === 'function') {


### PR DESCRIPTION
I have a use case where it makes sense to allow key bindings while focused on any input. I've added a flag for a backwards compatible way to allow this behavior following the convention used for the `keybindingsPlatformAgnostic` flag.
