### PR TITLE
Fix KeyboardEvent not passed to bound action

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,7 +46,7 @@ var Keybinding = {
     for (var i = 0; i < this.matchers.length; i++) {
       if (match(this.matchers[i].expectation, event)) {
         if (typeof this.matchers[i].action === 'function') {
-          this.matchers[i].action.apply(this, event);
+          this.matchers[i].action.apply(this, [event]);
         } else {
           if (typeof this.keybinding !== 'function') {
             throw new Error('non-function keybinding action given but no .keybinding method found on component');


### PR DESCRIPTION
(Sorry for making another pr, but I have no idea how to remove a commit from the pull request on Github.com, I didn't see it in the interface...
Edit: this web interface is really useless, did it properly in my git client)

I don't know if I'm the only one with that problem, but the KeyboardEvent was not passed to the bound action. And I needed the event to call the .preventDefault() method on the event.

(I also changed the version to react 0.14.1 because that's what I'm using for my project).

One thing I still would like to change is the default behavior on inputs. Right now, you chose to ignore keyboard events on inputs. I'd like to add an option to allow keybindings on inputs (when I have the time).
I think it's still useful because you might want to define keyboard shortcuts such as 'ctrl+enter' to do a certain action for the user (e.g. submit a form). Also, since react-keybinding does not prevent the default behavior for the event (if I'm correct), it won't affect the user input.

Anyways, nice module :).
