### PR TITLE
Express react dependency as a peerDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,13 +18,13 @@
   "devDependencies": {
     "browserify": "^9.0.3",
     "happen": "^0.1.3",
-    "react": "^0.12.2",
+    "react": "^0.13.3",
     "smokestack": "^3.2.0",
     "tap-closer": "^1.0.0",
     "tape": "^3.5.0"
   },
-  "dependencies": {
-    "react": "^0.13.0"
+  "peerDependencies": {
+    "react": "0.13.x || 0.14.x"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Applications should be able to choose their version of React, by moving
to a peerDependency react-keybinding will inherit the install version of
react. Extending supported version range from 0.13-0.14
