### PR TITLE
Refine keybindingsOnInputs

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,7 +42,7 @@ var Keybinding = {
    * and then either fires an inline method or the .keybinding() method.
    */
   __keybinding: function(event) {
-    if (isInput(event) && !!this.keybindingsOnInputs) return;
+    if (isInput(event) && !this.keybindingsOnInputs) return;
     for (var i = 0; i < this.matchers.length; i++) {
       if (match(this.matchers[i].expectation, event)) {
         if (typeof this.matchers[i].action === 'function') {


### PR DESCRIPTION
The default should be that keybindings on inputs are ignored, making
keybindingsOnInputs opt-in.
