### PR TITLE
use prop-types module instead React.PropTypes

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-var React = require('react'),
+var PropTypes = require('prop-types'),
   parseEvents = require('./src/parse_events.js'),
   isInput = require('./src/is_input.js'),
   match = require('./src/match.js');
@@ -13,10 +13,10 @@ var Keybinding = {
    * currently-active keybinding objects.
    */
   childContextTypes: {
-    __keybindings: React.PropTypes.array
+    __keybindings: PropTypes.array
   },
   contextTypes: {
-    __keybindings: React.PropTypes.array
+    __keybindings: PropTypes.array
   },
   getChildContext: function() {
     return { __keybindings: this.__getKeybindings() };

--- a/package.json
+++ b/package.json
@@ -1,33 +1,34 @@
 {
   "peerDependencies": {
     "react": ">=0.13.0 <16.0.0"
-  }, 
-  "name": "@mapbox/react-keybinding", 
-  "license": "MIT", 
-  "author": "Tom MacWright", 
+  },
+  "name": "@mapbox/react-keybinding",
+  "license": "MIT",
+  "author": "Tom MacWright",
   "repository": {
-    "url": "git@github.com:mapbox/react-keybinding.git", 
+    "url": "git@github.com:mapbox/react-keybinding.git",
     "type": "git"
-  }, 
-  "version": "3.0.0", 
+  },
+  "version": "3.0.0",
   "scripts": {
-    "test": "browserify test.js | tap-closer | smokestack", 
+    "test": "browserify test.js | tap-closer | smokestack",
     "test-ff": "node test.js && browserify test.js | tap-closer | smokestack -b firefox"
-  }, 
+  },
   "keywords": [
-    "keybinding", 
-    "keybindings", 
-    "react", 
+    "keybinding",
+    "keybindings",
+    "react",
     "react-component"
-  ], 
+  ],
   "devDependencies": {
-    "react": "^0.13.3", 
-    "tap-closer": "^1.0.0", 
-    "tape": "^3.5.0", 
-    "happen": "^0.1.3", 
-    "smokestack": "^3.2.0", 
-    "browserify": "^9.0.3"
-  }, 
-  "main": "index.js", 
+    "browserify": "^9.0.3",
+    "happen": "^0.1.3",
+    "prop-types": "^15.6.0",
+    "react": "^0.13.3",
+    "smokestack": "^3.2.0",
+    "tap-closer": "^1.0.0",
+    "tape": "^3.5.0"
+  },
+  "main": "index.js",
   "description": "declarative, concise keybindings for react"
 }


### PR DESCRIPTION
This change is to make this package compatible with react 16